### PR TITLE
OCaml test: increasing timeout by 1 retry attempt

### DIFF
--- a/scripts/mina-sync-monitor.sh
+++ b/scripts/mina-sync-monitor.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-max_attempts=6
+max_attempts=7
 attempt=0
 status="Null"
 sleep_duration=300


### PR DESCRIPTION
We are seeing faulty executions for the OCaml seed sync checks ([here](https://github.com/o1-labs/seeds/actions/workflows/ocaml-sync-check.yaml)).

While we setup an Alerts workflow, this PR slightly increases the timeout by adding a retry attempt.