### PR TITLE
Increasing timeout of sync test by a lot:

### DIFF
--- a/scripts/mina-sync-monitor.sh
+++ b/scripts/mina-sync-monitor.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-max_attempts=7
+max_attempts=10
 attempt=0
 status="Null"
 sleep_duration=300


### PR DESCRIPTION
This deals with issue https://github.com/o1-labs/seeds/issues/3, where tests failed mainly because there is not enough time for the daemon to sync to specific OCaml Seeds.