### PR TITLE
fix(ci): run scheduled OCaml sync checks instead of silently skipping

### DIFF
--- a/.github/workflows/devnet-sync-check.yaml
+++ b/.github/workflows/devnet-sync-check.yaml
@@ -22,9 +22,9 @@ concurrency:
 jobs:
   check-access:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Verify o1-labs/eng membership
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GENERAL_READ_GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ocaml-sync-check.yaml
+++ b/.github/workflows/ocaml-sync-check.yaml
@@ -22,9 +22,9 @@ concurrency:
 jobs:
   check-access:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Verify o1-labs/eng membership
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GENERAL_READ_GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Problem

Scheduled runs of the OCaml sync checks have been **silently skipping the actual sync test** while reporting ✅ `success`. Since the "eng team gate" commit (`9fc3342`, 2026-04-14), every scheduled run of `devnet-sync-check.yaml` and `ocaml-sync-check.yaml` completes in **~8 seconds** without running `test-peer`.

Evidence:
- **Per-run inspection** — in a scheduled run, `test-peer` and `print-failed-seeds` are `skipped`; in a manual `workflow_dispatch` run, all seed jobs run (~17 min each).
- **Control group** — `rust-sync-check.yaml` has no `check-access` gate and its scheduled runs execute normally (~2–3 min).
- **Before/after** — mainnet OCaml scheduled runs were **3–5 hours** of real testing before 2026-04-14, then dropped to **~8 s** immediately after the gate commit.

## Root cause

`check-access` was gated at the **job level** with `if: github.event_name == 'workflow_dispatch'`. On `schedule` that job is **skipped**, and GitHub Actions propagates the "skipped" state transitively down the `needs` chain (`check-access → parse → test-peer → print-failed-seeds`). `parse` survives only because it uses `always()`; `test-peer` / `print-failed-seeds` use the implicit `success()` condition and inherit the skip.

## Fix

Move the `if` from the **job** to the **membership step**, so `check-access` always runs and concludes `success` on schedule (the step just no-ops) — leaving no skipped job to taint the chain. Manual-dispatch authorization is unchanged: on `workflow_dispatch` the step still runs and an unauthorized actor fails it, which skips the chain.

```diff
   check-access:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Verify o1-labs/eng membership
+        if: github.event_name == 'workflow_dispatch'
```

Applied to both affected workflows — `devnet-sync-check.yaml` and `ocaml-sync-check.yaml`. `rust-sync-check.yaml` needs no change.

## Verification

- `actionlint` / `yamllint`: only pre-existing, unrelated warnings; nothing new from this change.
- Empirical confirmation comes after merge to `main` (scheduled workflows only run from the default branch). The next scheduled **devnet** run should go from ~8 s back to ~30–40 min and actually execute `test-peer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
